### PR TITLE
New rotations format

### DIFF
--- a/rotations.json
+++ b/rotations.json
@@ -1,85 +1,40 @@
 [
-  {
-    "code": "rotation-2017",
-    "cycles": [
-      "creation-and-control",
-      "honor-and-profit",
-      "lunar",
-      "order-and-chaos",
-      "sansan",
-      "data-and-destiny",
-      "mumbad",
-      "flashpoint",
-      "red-sand",
-      "terminal-directive",
-      "core2",
-      "kitara",
-      "reign-and-reverie",
-      "magnum-opus",
-      "ashes"
-    ],
-    "name": "First Rotation",
-    "date_start": "2017-10-01"
-  },
-  {
-    "code": "rotation-2018",
-    "cycles": [
-      "creation-and-control",
-      "honor-and-profit",
-      "lunar",
-      "order-and-chaos",
-      "sansan",
-      "data-and-destiny",
-      "mumbad",
-      "flashpoint",
-      "red-sand",
-      "kitara",
-      "reign-and-reverie",
-      "magnum-opus",
-      "sc19",
-      "ashes"
-    ],
-    "name": "Second Rotation",
-    "date_start": "2018-12-21"
-  },
-  {
-    "code": "rotation-2019",
-    "cycles": [
-      "honor-and-profit",
-      "order-and-chaos",
-      "sansan",
-      "data-and-destiny",
-      "mumbad",
-      "flashpoint",
-      "red-sand",
-      "kitara",
-      "reign-and-reverie",
-      "magnum-opus",
-      "sc19",
-      "ashes",
-      "magnum-opus-reprint",
-      "salvaged-memories"
-    ],
-    "name": "Third Rotation",
-    "date_start": "2019-12-27"
-  },
-  {
-    "code": "rotation-2021",
-    "cycles": [
-      "order-and-chaos",
-      "data-and-destiny",
-      "mumbad",
-      "flashpoint",
-      "red-sand",
-      "kitara",
-      "reign-and-reverie",
-      "magnum-opus",
-      "ashes",
-      "magnum-opus-reprint",
-      "system-gateway",
-      "system-update-2021"
-    ],
-    "name": "Fourth Rotation",
-    "date_start": "2021-04-09"
-  }
+    {
+        "code": "rotation-2017",
+        "date_start": "2017-10-01",
+        "name": "First Rotation",
+        "rotated": [
+            "core", "genesis", "spin"
+        ]
+    },
+    {
+        "code": "rotation-2018",
+        "name": "Second Rotation",
+        "date_start": "2018-12-21",
+        "rotated": [
+            "core", "genesis", "spin",
+            "core2", "terminal-directive"
+        ]
+    },
+    {
+        "code": "rotation-2019",
+        "name": "Third Rotation",
+        "date_start": "2019-12-27",
+        "rotated": [
+            "core", "genesis", "spin",
+            "core2", "terminal-directive",
+            "creation-and-control", "lunar"
+        ]
+    },
+    {
+        "code": "rotation-2021",
+        "name": "Fourth Rotation",
+        "date_start": "2021-04-09",
+        "rotated": [
+            "core", "genesis", "spin",
+            "core2", "terminal-directive",
+            "creation-and-control", "lunar",
+            "sc19", "honor-and-profit", "sansan", "salvaged-memories"
+        ]
+    }
 ]

--- a/rotations.json
+++ b/rotations.json
@@ -4,37 +4,53 @@
         "date_start": "2017-10-01",
         "name": "First Rotation",
         "rotated": [
-            "core", "genesis", "spin"
+            "core",
+            "genesis",
+            "spin"
         ]
     },
     {
         "code": "rotation-2018",
-        "name": "Second Rotation",
         "date_start": "2018-12-21",
+        "name": "Second Rotation",
         "rotated": [
-            "core", "genesis", "spin",
-            "core2", "terminal-directive"
+            "core",
+            "genesis",
+            "spin",
+            "core2",
+            "terminal-directive"
         ]
     },
     {
         "code": "rotation-2019",
-        "name": "Third Rotation",
         "date_start": "2019-12-27",
+        "name": "Third Rotation",
         "rotated": [
-            "core", "genesis", "spin",
-            "core2", "terminal-directive",
-            "creation-and-control", "lunar"
+            "core",
+            "genesis",
+            "spin",
+            "core2",
+            "terminal-directive",
+            "creation-and-control",
+            "lunar"
         ]
     },
     {
         "code": "rotation-2021",
-        "name": "Fourth Rotation",
         "date_start": "2021-04-09",
+        "name": "Fourth Rotation",
         "rotated": [
-            "core", "genesis", "spin",
-            "core2", "terminal-directive",
-            "creation-and-control", "lunar",
-            "sc19", "honor-and-profit", "sansan", "salvaged-memories"
+            "core",
+            "genesis",
+            "spin",
+            "core2",
+            "terminal-directive",
+            "creation-and-control",
+            "lunar",
+            "sc19",
+            "honor-and-profit",
+            "sansan",
+            "salvaged-memories"
         ]
     }
 ]

--- a/schema/rotations_schema.json
+++ b/schema/rotations_schema.json
@@ -1,0 +1,36 @@
+{
+    "additionalProperties": false,
+    "properties": {
+        "code": {
+            "minLength": 1,
+            "type": "string"
+        },
+        "date_start": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "name": {
+            "minLength": 1,
+            "type": "string"
+        },
+        "rotated": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "code",
+        "date_start",
+        "name",
+        "rotated"
+    ],
+    "type": "object"
+}

--- a/validate.py
+++ b/validate.py
@@ -358,6 +358,34 @@ def validate_sides(args, sides_data):
 
     return retval
 
+def validate_rotations(args, rot_data):
+    global validation_errors
+
+    verbose_print(args, "Validating rotations ...\n", 1)
+    rot_schema_path = os.path.join(args.schema_path, "rotations_schema.json")
+    ROT_SCHEMA = load_json_file(args, rot_schema_path)
+    if not isinstance(rot_data, list):
+        verbose_print(args, "Insides of rotations index file are not a list!\n", 0)
+        return False
+    if not ROT_SCHEMA:
+        return False
+    if not check_json_schema(args, ROT_SCHEMA, rot_schema_path):
+        return False
+
+    retval = True
+    for c in rot_data:
+        try:
+            verbose_print(args, "Validating rotation %s... " % c.get("name"), 2)
+            jsonschema.validate(c, ROT_SCHEMA)
+            verbose_print(args, "OK\n", 2)
+        except jsonschema.ValidationError as e:
+            verbose_print(args, "ERROR\n",2)
+            verbose_print(args, "Validation error in rotation: (code: '%s' name: '%s')\n" % (c.get("code"), c.get("name")), 0)
+            validation_errors += 1
+            verbose_print(args, "%s\n" % e.message, 0)
+            retval = False
+
+    return retval
 def check_translations_simple(args, base_translations_path, locale_name, base_file_name):
     file_name = "%s.%s.json" % (base_file_name, locale_name)
     verbose_print(args, "Loading file %s...\n" % file_name, 1)
@@ -396,8 +424,14 @@ def check_mwl(args):
 
 def check_prebuilt(args):
     verbose_print(args, "Loading Prebuilts...\n", 1)
-    mwl_path = os.path.join(args.base_path, "prebuilts.json")
-    load_json_file(args, mwl_path)
+    pre_path = os.path.join(args.base_path, "prebuilts.json")
+    load_json_file(args, pre_path)
+
+def check_rotation(args):
+    verbose_print(args, "Loading Rotations...\n", 1)
+    rot_path = os.path.join(args.base_path, "rotations.json")
+    rot_data = load_json_file(args, rot_path)
+    validate_rotations(args, rot_data)
 
 def verbose_print(args, text, minimum_verbosity=0):
     if args.verbose >= minimum_verbosity:
@@ -430,6 +464,8 @@ def main():
         verbose_print(args, "Skipping card validation...\n", 0)
 
     check_prebuilt(args)
+
+    check_rotation(args)
 
     check_mwl(args)
 


### PR DESCRIPTION
This inverts the logic of `rotations.json` - instead of listing what's legal after this rotation, we now specify what's rotating out.

This PR requires a db schema change in NetrunnerDB, see https://github.com/NetrunnerDB/netrunnerdb/pull/512