### PR TITLE
Fix Vitruvius cost and Whitespace FT

### DIFF
--- a/pack/sg.json
+++ b/pack/sg.json
@@ -1491,7 +1491,7 @@
         "deck_limit": 3,
         "faction_code": "neutral-corp",
         "faction_cost": 0,
-        "flavor": "{ca}[this space intentionally left blank]{/ca}",
+        "flavor": "[this space intentionally left blank]",
         "illustrator": "Scott Uminga",
         "keywords": "Code Gate",
         "pack_code": "sg",

--- a/pack/su21.json
+++ b/pack/su21.json
@@ -830,7 +830,7 @@
         "side_code": "corp",
         "stripped_text": "When you score this agenda, place 1 agenda counter on it for each hosted advancement counter past 3. Hosted agenda counter: Add 1 card from Archives to HQ.",
         "stripped_title": "Project Vitruvius",
-        "text": "When you score this agenda, place 1 agenda counter on it for each hosted advancement counter past 3.\nHosted agenda counter: Add 1 card from Archives to HQ.",
+        "text": "When you score this agenda, place 1 agenda counter on it for each hosted advancement counter past 3.\n<strong>Hosted agenda counter:</strong> Add 1 card from Archives to HQ.",
         "title": "Project Vitruvius",
         "type_code": "agenda",
         "uniqueness": false


### PR DESCRIPTION
Fix Vitruvius' cost in SU21 (make it bold) and remove the layout tags in Whitespace's FT.

Haven't yet gotten to updating the formatting for other versions of SU21 cards (so Vitruvius in SC19 doesn't have a bold cost yet).