### PR TITLE
Fixed VRcation's quotation marks

### DIFF
--- a/pack/sg.json
+++ b/pack/sg.json
@@ -416,7 +416,7 @@
     "deck_limit": 3,
     "faction_code": "shaper",
     "faction_cost": 2,
-    "flavor": "“You know there's no water in the Sea of Tranquility, right?”\n“That doesn't mean there's no beach.”",
+    "flavor": "\"You know there's no water in the Sea of Tranquility, right?\"\n\"That doesn't mean there's no beach.\"",
     "illustrator": "Benjamin Giletti",
     "pack_code": "sg",
     "position": 21,


### PR DESCRIPTION
VRcation is unique in using standard escaped double quotation marks in its flavor text. I assume this is an error.