### PR TITLE
Removed all instances of <i> and replaced them with <em>

### DIFF
--- a/cards/secure_and_protect.json
+++ b/cards/secure_and_protect.json
@@ -10,6 +10,6 @@
   "stripped_text": "As an additional cost to play this operation, spend click. Search R&D for a piece of ice and reveal it. (Shuffle R&D after searching it.) Install that ice protecting a central server, paying 3 credits less.",
   "stripped_title": "Secure and Protect",
   "subtypes": ["double"],
-  "text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <i>(Shuffle R&D after searching it.)</i> Install that ice protecting a central server, paying 3[credit] less.",
+  "text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <em>(Shuffle R&D after searching it.)</em> Install that ice protecting a central server, paying 3[credit] less.",
   "title": "Secure and Protect"
 }

--- a/cards/storgotic_resonator.json
+++ b/cards/storgotic_resonator.json
@@ -10,7 +10,7 @@
   "stripped_text": "The first time each turn you trash (from any location) a card that matches the faction of the Runner's identity, place 1 power counter on this asset. click, hosted power counter: Do 1 net damage.",
   "stripped_title": "Storgotic Resonator",
   "subtypes": ["hostile"],
-  "text": "The first time each turn you trash <i>(from any location)</i> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
+  "text": "The first time each turn you trash <em>(from any location)</em> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
   "title": "Storgotic Resonator",
   "trash_cost": 2
 }

--- a/cards/whistleblower.json
+++ b/cards/whistleblower.json
@@ -10,6 +10,6 @@
   "stripped_text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. (You are no longer accessing it.)",
   "stripped_title": "Whistleblower",
   "subtypes": ["connection"],
-  "text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <i>(You are no longer accessing it.)</i>",
+  "text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <em>(You are no longer accessing it.)</em>",
   "title": "Whistleblower"
 }

--- a/pack/df.json
+++ b/pack/df.json
@@ -595,7 +595,7 @@
     "side_code": "runner",
     "stripped_text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. (You are no longer accessing it.)",
     "stripped_title": "Whistleblower",
-    "text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <i>(You are no longer accessing it.)</i>",
+    "text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <em>(You are no longer accessing it.)</em>",
     "title": "Whistleblower",
     "type_code": "resource",
     "uniqueness": true
@@ -856,7 +856,7 @@
     "side_code": "corp",
     "stripped_text": "The first time each turn you trash (from any location) a card that matches the faction of the Runner's identity, place 1 power counter on this asset. click, hosted power counter: Do 1 net damage.",
     "stripped_title": "Storgotic Resonator",
-    "text": "The first time each turn you trash <i>(from any location)</i> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
+    "text": "The first time each turn you trash <em>(from any location)</em> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
     "title": "Storgotic Resonator",
     "trash_cost": 2,
     "type_code": "asset",
@@ -1220,7 +1220,7 @@
     "side_code": "corp",
     "stripped_text": "As an additional cost to play this operation, spend click. Search R&D for a piece of ice and reveal it. (Shuffle R&D after searching it.) Install that ice protecting a central server, paying 3 credits less.",
     "stripped_title": "Secure and Protect",
-    "text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <i>(Shuffle R&D after searching it.)</i> Install that ice protecting a central server, paying 3[credit] less.",
+    "text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <em>(Shuffle R&D after searching it.)</em> Install that ice protecting a central server, paying 3[credit] less.",
     "title": "Secure and Protect",
     "type_code": "operation",
     "uniqueness": false

--- a/printings/df.json
+++ b/printings/df.json
@@ -352,7 +352,7 @@
     "illustrator": "Olie Boldador",
     "position": 30,
     "printed_is_unique": true,
-    "printed_text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <i>(You are no longer accessing it.)</i>",
+    "printed_text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <em>(You are no longer accessing it.)</em>",
     "quantity": 3,
     "stripped_printed_text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. (You are no longer accessing it.)"
   },
@@ -506,7 +506,7 @@
     "illustrator": "Krembler",
     "position": 43,
     "printed_is_unique": true,
-    "printed_text": "The first time each turn you trash <i>(from any location)</i> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
+    "printed_text": "The first time each turn you trash <em>(from any location)</em> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
     "quantity": 3,
     "stripped_printed_text": "The first time each turn you trash (from any location) a card that matches the faction of the Runner's identity, place 1 power counter on this asset. click, hosted power counter: Do 1 net damage."
   },
@@ -717,7 +717,7 @@
     "illustrator": "Krembler",
     "position": 61,
     "printed_is_unique": false,
-    "printed_text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <i>(Shuffle R&D after searching it.)</i> Install that ice protecting a central server, paying 3[credit] less.",
+    "printed_text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <em>(Shuffle R&D after searching it.)</em> Install that ice protecting a central server, paying 3[credit] less.",
     "quantity": 3,
     "stripped_printed_text": "As an additional cost to play this operation, spend click. Search R&D for a piece of ice and reveal it. (Shuffle R&D after searching it.) Install that ice protecting a central server, paying 3 credits less."
   },


### PR DESCRIPTION
A few cards in Ashes use the wrong tags for italics. This updates them to the existing standard of using `<em>`.