### PR TITLE
Add legacy_code fields to Card Cycles and Sets.

### DIFF
--- a/schema/v2/card_cycles_schema.json
+++ b/schema/v2/card_cycles_schema.json
@@ -10,6 +10,10 @@
         "minLength": 1,
         "type": "string"
       },
+      "legacy_code": {
+        "minLength": 1,
+        "type": "string"
+      },
       "name": {
         "minLength": 1,
         "type": "string"
@@ -18,6 +22,6 @@
         "type": "string"
       }
     },
-    "required": ["id", "name"]
+    "required": ["id", "legacy_code", "name"]
   }
 }

--- a/schema/v2/card_sets_schema.json
+++ b/schema/v2/card_sets_schema.json
@@ -22,6 +22,10 @@
         "minLength": 1,
         "type": "string"
       },
+      "legacy_code": {
+        "minLength": 1,
+        "type": "string"
+      },
       "name": {
         "minLength": 1,
         "type": "string"
@@ -40,6 +44,7 @@
       "card_set_type_id",
       "date_release",
       "id",
+      "legacy_code",
       "name",
       "position",
       "size"

--- a/test/validate_v1_v2_equality.ts
+++ b/test/validate_v1_v2_equality.ts
@@ -35,10 +35,8 @@ describe('Card Sets v1/v2', () => {
   getPacksJson().forEach(p => {
     packsByCode.set(p.code, p);
   });
-  const cardSetsById = new Map<string, string>();
   const cardSetsByCode = new Map<string, any>();
   getCardSetsV2Json().forEach(s => {
-    cardSetsById.set(s.id, s.name);
     cardSetsByCode.set(s.legacy_code, s);
   });
 

--- a/test/validate_v1_v2_equality.ts
+++ b/test/validate_v1_v2_equality.ts
@@ -1,5 +1,65 @@
-import { getCardsJson, getCardSetsV2Json, getCardsV2Json, getPacksJson, getPrintingsV2Json, textToId } from "../src/index";
+import { getCardsJson, getCardCyclesV2Json, getCardSetsV2Json, getCardsV2Json, getCyclesJson, getPacksJson, getPrintingsV2Json, textToId } from "../src/index";
 import { expect } from "chai";
+
+describe('Card Cycles v1/v2', () => {
+  // id in v2 is the textToId'd version of the set name, not the same as the NRDB classic code.
+  const cyclesByCode = new Map<string, string>();
+  getCyclesJson().forEach(c => {
+    cyclesByCode.set(c.code, c.name);
+  });
+  const cardCyclesByLegacyCode = new Map<string, string>();
+  getCardCyclesV2Json().forEach(s => {
+    cardCyclesByLegacyCode.set(s.legacy_code, s.name);
+  });
+
+  it('has correct number of cardCycles', () => {
+    expect(cardCyclesByLegacyCode.size).to.equal(cyclesByCode.size); 
+  });
+
+  it('has matching card cycle attributes', () => {
+    cardCyclesByLegacyCode.forEach((name, legacyCode) => {
+      expect(cyclesByCode.has(legacyCode), `legacy_code ${legacyCode} exists in packsByCode map`).to.be.true;
+      expect(name, `name mismatch for card set ${name} with legacy_code ${legacyCode}`).to.equal(cyclesByCode.get(legacyCode));
+    });
+  });
+});
+
+describe('Card Sets v1/v2', () => {
+  const cardCycleIdToLegacyCode = new Map<string, string>();
+  getCardCyclesV2Json().forEach(s => {
+    cardCycleIdToLegacyCode.set(s.id, s.legacy_code);
+  });
+
+  // card_set_id in v2 is the textToId'd version of the set name, not the same as the NRDB classic code.
+  const packsByCode = new Map<string, any>();
+  getPacksJson().forEach(p => {
+    packsByCode.set(p.code, p);
+  });
+  const cardSetsById = new Map<string, string>();
+  const cardSetsByCode = new Map<string, any>();
+  getCardSetsV2Json().forEach(s => {
+    cardSetsById.set(s.id, s.name);
+    cardSetsByCode.set(s.legacy_code, s);
+  });
+
+  it('correct number of card cardCycles', () => {
+    expect(cardSetsByCode.size).to.equal(packsByCode.size); 
+  });
+
+  it('card set attributes match', () => {
+    cardSetsByCode.forEach((cardSet, legacyCode) => {
+      expect(cardCycleIdToLegacyCode.get(cardSet.card_cycle_id), `card set ${cardSet.name} has matching cycle id`).to.equal(packsByCode.get(legacyCode).cycle_code);
+      expect(packsByCode.has(legacyCode), `legacy_code ${legacyCode} exists in packsByCode map`).to.be.true;
+      if (legacyCode != 'draft') {
+        // v1 does not have a release date or size set for draft.
+        expect(cardSet.date_release, `date_release mismatch for card set ${cardSet.name} with legacy_code ${legacyCode}`).to.equal(packsByCode.get(legacyCode).date_release);
+        expect(cardSet.size, `size mismatch for card set ${cardSet.name} with legacy_code ${legacyCode}`).to.equal(packsByCode.get(legacyCode).size);
+      }
+      expect(cardSet.name, `name mismatch for card set ${cardSet.name} with legacy_code ${legacyCode}`).to.equal(packsByCode.get(legacyCode).name);
+      expect(cardSet.position, `position mismatch for card set ${cardSet.name} with legacy_code ${legacyCode}`).to.equal(packsByCode.get(legacyCode).position);
+    });
+  });
+});
 
 describe('Cards v1/v2 equality', () => {
   const v1CardsByTitle = new Map<string, any>();
@@ -143,23 +203,23 @@ describe('Printings v1/v2 equality', () => {
   }
 
   // card_set_id in v2 is the textToId'd version of the set name, not a code.
-  // Validate the ids for sets via the retrieved set, not the name directly.
+  // Validate the ids for cardCycles via the retrieved set, not the name directly.
   const packs = getPacksJson();
   const packsByCode = new Map<string, string>();
   packs.forEach(p => {
     packsByCode.set(p.code, p.name);
   });
-  const sets = getCardSetsV2Json();
-  const setsById = new Map<string, string>();
-  sets.forEach(s => {
-    setsById.set(s.id, s.name);
+  const cardCycles = getCardSetsV2Json();
+  const cardCyclesById = new Map<string, string>();
+  cardCycles.forEach(s => {
+    cardCyclesById.set(s.id, s.name);
   });
 
   it('card set matches pack names.', () => {
     v1CardsByCode.forEach((v1, code) => {
       expect(packsByCode.get(v1.pack_code),
           `Card set mismatch for printing id ${code} for ${v1CardsByCode.get(code).title}`)
-        .to.equal(setsById.get(printingsById.get(code).card_set_id));
+        .to.equal(cardCyclesById.get(printingsById.get(code).card_set_id));
     });
   });
 

--- a/test/validate_v1_v2_equality.ts
+++ b/test/validate_v1_v2_equality.ts
@@ -201,23 +201,23 @@ describe('Printings v1/v2 equality', () => {
   }
 
   // card_set_id in v2 is the textToId'd version of the set name, not a code.
-  // Validate the ids for cardCycles via the retrieved set, not the name directly.
+  // Validate the ids for sets via the retrieved set, not the name directly.
   const packs = getPacksJson();
   const packsByCode = new Map<string, string>();
   packs.forEach(p => {
     packsByCode.set(p.code, p.name);
   });
-  const cardCycles = getCardSetsV2Json();
-  const cardCyclesById = new Map<string, string>();
-  cardCycles.forEach(s => {
-    cardCyclesById.set(s.id, s.name);
+  const sets = getCardSetsV2Json();
+  const setsById = new Map<string, string>();
+  sets.forEach(s => {
+    setsById.set(s.id, s.name);
   });
 
   it('card set matches pack names.', () => {
     v1CardsByCode.forEach((v1, code) => {
       expect(packsByCode.get(v1.pack_code),
           `Card set mismatch for printing id ${code} for ${v1CardsByCode.get(code).title}`)
-        .to.equal(cardCyclesById.get(printingsById.get(code).card_set_id));
+        .to.equal(setsById.get(printingsById.get(code).card_set_id));
     });
   });
 

--- a/v2/card_cycles.json
+++ b/v2/card_cycles.json
@@ -1,106 +1,132 @@
 [
   {
     "id": "draft",
+    "legacy_code": "draft",
     "name": "Draft"
   },
   {
     "id": "core_set",
+    "legacy_code": "core",
     "name": "Core Set"
   },
   {
     "id": "genesis",
+    "legacy_code": "genesis",
     "name": "Genesis"
   },
   {
     "id": "creation_and_control",
+    "legacy_code": "creation-and-control",
     "name": "Creation and Control"
   },
   {
     "id": "spin",
+    "legacy_code": "spin",
     "name": "Spin"
   },
   {
     "id": "honor_and_profit",
+    "legacy_code": "honor-and-profit",
     "name": "Honor and Profit"
   },
   {
     "id": "lunar",
+    "legacy_code": "lunar",
     "name": "Lunar"
   },
   {
     "id": "order_and_chaos",
+    "legacy_code": "order-and-chaos",
     "name": "Order and Chaos"
   },
   {
     "id": "sansan",
+    "legacy_code": "sansan",
     "name": "SanSan"
   },
   {
     "id": "data_and_destiny",
+    "legacy_code": "data-and-destiny",
     "name": "Data and Destiny"
   },
   {
     "id": "mumbad",
+    "legacy_code": "mumbad",
     "name": "Mumbad"
   },
   {
     "id": "flashpoint",
+    "legacy_code": "flashpoint",
     "name": "Flashpoint"
   },
   {
     "id": "red_sand",
+    "legacy_code": "red-sand",
     "name": "Red Sand"
   },
   {
     "id": "terminal_directive",
+    "legacy_code": "terminal-directive",
     "name": "Terminal Directive"
   },
   {
     "id": "revised_core_set",
+    "legacy_code": "core2",
     "name": "Revised Core Set"
   },
   {
     "id": "kitara",
+    "legacy_code": "kitara",
     "name": "Kitara"
   },
   {
     "id": "reign_and_reverie",
+    "legacy_code": "reign-and-reverie",
     "name": "Reign and Reverie"
   },
   {
     "id": "magnum_opus",
+    "legacy_code": "magnum-opus",
     "name": "Magnum Opus"
   },
   {
     "id": "napd_multiplayer",
+    "legacy_code": "napd",
     "name": "NAPD Multiplayer"
   },
   {
     "id": "system_core_2019",
+    "legacy_code": "sc19",
     "name": "System Core 2019"
   },
   {
     "id": "ashes",
+    "legacy_code": "ashes",
     "name": "Ashes"
   },
   {
     "id": "magnum_opus_reprint",
+    "legacy_code": "magnum-opus-reprint",
     "name": "Magnum Opus Reprint"
   },
   {
     "id": "salvaged_memories",
+    "legacy_code": "salvaged-memories",
     "name": "Salvaged Memories"
   },
   {
     "id": "system_gateway",
+    "legacy_code": "system-gateway",
     "name": "System Gateway"
   },
   {
     "id": "system_update_2021",
+    "legacy_code": "system-update-2021",
     "name": "System Update 2021"
   },
   {
     "id": "borealis",
+    "legacy_code": "borealis",
     "name": "Borealis"
   }
 ]

--- a/v2/card_sets.json
+++ b/v2/card_sets.json
@@ -4,6 +4,7 @@
     "card_set_type_id": "draft",
     "date_release": "2012-09-07",
     "id": "draft",
+    "legacy_code": "draft",
     "name": "Draft",
     "position": 1,
     "size": 1
@@ -13,6 +14,7 @@
     "card_set_type_id": "core",
     "date_release": "2012-09-06",
     "id": "core_set",
+    "legacy_code": "core",
     "name": "Core Set",
     "position": 1,
     "size": 113
@@ -22,6 +24,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2012-12-14",
     "id": "what_lies_ahead",
+    "legacy_code": "wla",
     "name": "What Lies Ahead",
     "position": 1,
     "size": 20
@@ -31,6 +34,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-01-09",
     "id": "trace_amount",
+    "legacy_code": "ta",
     "name": "Trace Amount",
     "position": 2,
     "size": 20
@@ -40,6 +44,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-02-14",
     "id": "cyber_exodus",
+    "legacy_code": "ce",
     "name": "Cyber Exodus",
     "position": 3,
     "size": 20
@@ -49,6 +54,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-03-21",
     "id": "a_study_in_static",
+    "legacy_code": "asis",
     "name": "A Study in Static",
     "position": 4,
     "size": 20
@@ -58,6 +64,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-05-02",
     "id": "humanitys_shadow",
+    "legacy_code": "hs",
     "name": "Humanity's Shadow",
     "position": 5,
     "size": 20
@@ -67,6 +74,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-05-30",
     "id": "future_proof",
+    "legacy_code": "fp",
     "name": "Future Proof",
     "position": 6,
     "size": 20
@@ -76,6 +84,7 @@
     "card_set_type_id": "deluxe",
     "date_release": "2013-07-29",
     "id": "creation_and_control",
+    "legacy_code": "cac",
     "name": "Creation and Control",
     "position": 1,
     "size": 55
@@ -85,6 +94,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-09-27",
     "id": "opening_moves",
+    "legacy_code": "om",
     "name": "Opening Moves",
     "position": 1,
     "size": 20
@@ -94,6 +104,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-11-07",
     "id": "second_thoughts",
+    "legacy_code": "st",
     "name": "Second Thoughts",
     "position": 2,
     "size": 20
@@ -103,6 +114,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2013-12-13",
     "id": "mala_tempora",
+    "legacy_code": "mt",
     "name": "Mala Tempora",
     "position": 3,
     "size": 20
@@ -112,6 +124,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-01-17",
     "id": "true_colors",
+    "legacy_code": "tc",
     "name": "True Colors",
     "position": 4,
     "size": 20
@@ -121,6 +134,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-02-21",
     "id": "fear_and_loathing",
+    "legacy_code": "fal",
     "name": "Fear and Loathing",
     "position": 5,
     "size": 20
@@ -130,6 +144,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-03-28",
     "id": "double_time",
+    "legacy_code": "dt",
     "name": "Double Time",
     "position": 6,
     "size": 20
@@ -139,6 +154,7 @@
     "card_set_type_id": "deluxe",
     "date_release": "2014-05-02",
     "id": "honor_and_profit",
+    "legacy_code": "hap",
     "name": "Honor and Profit",
     "position": 1,
     "size": 55
@@ -148,6 +164,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-07-25",
     "id": "upstalk",
+    "legacy_code": "up",
     "name": "Upstalk",
     "position": 1,
     "size": 20
@@ -157,6 +174,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-08-15",
     "id": "the_spaces_between",
+    "legacy_code": "tsb",
     "name": "The Spaces Between",
     "position": 2,
     "size": 20
@@ -166,6 +184,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-09-15",
     "id": "first_contact",
+    "legacy_code": "fc",
     "name": "First Contact",
     "position": 3,
     "size": 20
@@ -175,6 +194,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-10-16",
     "id": "up_and_over",
+    "legacy_code": "uao",
     "name": "Up and Over",
     "position": 4,
     "size": 20
@@ -184,6 +204,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-11-13",
     "id": "all_that_remains",
+    "legacy_code": "atr",
     "name": "All That Remains",
     "position": 5,
     "size": 20
@@ -193,6 +214,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2014-12-18",
     "id": "the_source",
+    "legacy_code": "ts",
     "name": "The Source",
     "position": 6,
     "size": 20
@@ -202,6 +224,7 @@
     "card_set_type_id": "deluxe",
     "date_release": "2015-01-28",
     "id": "order_and_chaos",
+    "legacy_code": "oac",
     "name": "Order and Chaos",
     "position": 1,
     "size": 55
@@ -211,6 +234,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2015-04-03",
     "id": "the_valley",
+    "legacy_code": "val",
     "name": "The Valley",
     "position": 1,
     "size": 20
@@ -220,6 +244,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2015-04-24",
     "id": "breaker_bay",
+    "legacy_code": "bb",
     "name": "Breaker Bay",
     "position": 2,
     "size": 20
@@ -229,6 +254,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2015-05-29",
     "id": "chrome_city",
+    "legacy_code": "cc",
     "name": "Chrome City",
     "position": 3,
     "size": 20
@@ -238,6 +264,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2015-07-02",
     "id": "the_underway",
+    "legacy_code": "uw",
     "name": "The Underway",
     "position": 4,
     "size": 20
@@ -247,6 +274,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2015-08-06",
     "id": "old_hollywood",
+    "legacy_code": "oh",
     "name": "Old Hollywood",
     "position": 5,
     "size": 20
@@ -256,6 +284,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2015-09-03",
     "id": "the_universe_of_tomorrow",
+    "legacy_code": "uot",
     "name": "The Universe of Tomorrow",
     "position": 6,
     "size": 20
@@ -265,6 +294,7 @@
     "card_set_type_id": "deluxe",
     "date_release": "2015-10-29",
     "id": "data_and_destiny",
+    "legacy_code": "dad",
     "name": "Data and Destiny",
     "position": 1,
     "size": 55
@@ -274,6 +304,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-01-29",
     "id": "kala_ghoda",
+    "legacy_code": "kg",
     "name": "Kala Ghoda",
     "position": 1,
     "size": 19
@@ -283,6 +314,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-03-11",
     "id": "business_first",
+    "legacy_code": "bf",
     "name": "Business First",
     "position": 2,
     "size": 19
@@ -292,6 +324,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-04-01",
     "id": "democracy_and_dogma",
+    "legacy_code": "dag",
     "name": "Democracy and Dogma",
     "position": 3,
     "size": 19
@@ -301,6 +334,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-04-28",
     "id": "salsette_island",
+    "legacy_code": "si",
     "name": "Salsette Island",
     "position": 4,
     "size": 19
@@ -310,6 +344,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-05-26",
     "id": "the_liberated_mind",
+    "legacy_code": "tlm",
     "name": "The Liberated Mind",
     "position": 5,
     "size": 19
@@ -319,6 +354,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-06-16",
     "id": "fear_the_masses",
+    "legacy_code": "ftm",
     "name": "Fear the Masses",
     "position": 6,
     "size": 19
@@ -328,6 +364,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-07-14",
     "id": "23_seconds",
+    "legacy_code": "23s",
     "name": "23 Seconds",
     "position": 1,
     "size": 20
@@ -337,6 +374,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-08-11",
     "id": "blood_money",
+    "legacy_code": "bm",
     "name": "Blood Money",
     "position": 2,
     "size": 20
@@ -346,6 +384,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-10-06",
     "id": "escalation",
+    "legacy_code": "es",
     "name": "Escalation",
     "position": 3,
     "size": 20
@@ -355,6 +394,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-11-03",
     "id": "intervention",
+    "legacy_code": "in",
     "name": "Intervention",
     "position": 4,
     "size": 20
@@ -364,6 +404,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2016-12-08",
     "id": "martial_law",
+    "legacy_code": "ml",
     "name": "Martial Law",
     "position": 5,
     "size": 20
@@ -373,6 +414,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-01-12",
     "id": "quorum",
+    "legacy_code": "qu",
     "name": "Quorum",
     "position": 6,
     "size": 20
@@ -382,6 +424,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-02-23",
     "id": "daedalus_complex",
+    "legacy_code": "dc",
     "name": "Daedalus Complex",
     "position": 1,
     "size": 20
@@ -391,6 +434,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-03-23",
     "id": "station_one",
+    "legacy_code": "so",
     "name": "Station One",
     "position": 2,
     "size": 20
@@ -400,6 +444,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-04-27",
     "id": "terminal_directive_cards",
+    "legacy_code": "td",
     "name": "Terminal Directive Cards",
     "position": 1,
     "size": 57
@@ -409,6 +454,7 @@
     "card_set_type_id": "campaign",
     "date_release": "2017-04-27",
     "id": "terminal_directive_campaign",
+    "legacy_code": "tdc",
     "name": "Terminal Directive Campaign",
     "position": 2,
     "size": 18
@@ -418,6 +464,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-05-25",
     "id": "earths_scion",
+    "legacy_code": "eas",
     "name": "Earth's Scion",
     "position": 3,
     "size": 20
@@ -427,6 +474,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-06-22",
     "id": "blood_and_water",
+    "legacy_code": "baw",
     "name": "Blood and Water",
     "position": 4,
     "size": 20
@@ -436,6 +484,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-07-20",
     "id": "free_mars",
+    "legacy_code": "fm",
     "name": "Free Mars",
     "position": 5,
     "size": 20
@@ -445,6 +494,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-08-17",
     "id": "crimson_dust",
+    "legacy_code": "cd",
     "name": "Crimson Dust",
     "position": 6,
     "size": 20
@@ -454,6 +504,7 @@
     "card_set_type_id": "core",
     "date_release": "2017-12-14",
     "id": "revised_core_set",
+    "legacy_code": "core2",
     "name": "Revised Core Set",
     "position": 1,
     "size": 132
@@ -463,6 +514,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2017-12-28",
     "id": "sovereign_sight",
+    "legacy_code": "ss",
     "name": "Sovereign Sight",
     "position": 1,
     "size": 20
@@ -472,6 +524,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2018-02-01",
     "id": "down_the_white_nile",
+    "legacy_code": "dtwn",
     "name": "Down the White Nile",
     "position": 2,
     "size": 20
@@ -481,6 +534,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2018-03-01",
     "id": "council_of_the_crest",
+    "legacy_code": "cotc",
     "name": "Council of the Crest",
     "position": 3,
     "size": 20
@@ -490,6 +544,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2018-04-05",
     "id": "the_devil_and_the_dragon",
+    "legacy_code": "tdatd",
     "name": "The Devil and the Dragon",
     "position": 4,
     "size": 20
@@ -499,6 +554,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2018-05-03",
     "id": "whispers_in_nalubaale",
+    "legacy_code": "win",
     "name": "Whispers in Nalubaale",
     "position": 5,
     "size": 20
@@ -508,6 +564,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2018-05-31",
     "id": "kampala_ascendent",
+    "legacy_code": "ka",
     "name": "Kampala Ascendent",
     "position": 6,
     "size": 20
@@ -517,6 +574,7 @@
     "card_set_type_id": "deluxe",
     "date_release": "2018-06-28",
     "id": "reign_and_reverie",
+    "legacy_code": "rar",
     "name": "Reign and Reverie",
     "position": 1,
     "size": 58
@@ -526,6 +584,7 @@
     "card_set_type_id": "expansion",
     "date_release": "2018-09-07",
     "id": "magnum_opus",
+    "legacy_code": "mo",
     "name": "Magnum Opus",
     "position": 1,
     "size": 8
@@ -535,6 +594,7 @@
     "card_set_type_id": "promo",
     "date_release": "2018-09-07",
     "id": "napd_multiplayer",
+    "legacy_code": "napd",
     "name": "NAPD Multiplayer",
     "position": 1,
     "size": 1
@@ -544,6 +604,7 @@
     "card_set_type_id": "core",
     "date_release": "2018-12-21",
     "id": "system_core_2019",
+    "legacy_code": "sc19",
     "name": "System Core 2019",
     "position": 1,
     "size": 147
@@ -553,6 +614,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2019-03-18",
     "id": "downfall",
+    "legacy_code": "df",
     "name": "Downfall",
     "position": 1,
     "size": 65
@@ -562,6 +624,7 @@
     "card_set_type_id": "expansion",
     "date_release": "2019-07-24",
     "id": "magnum_opus_reprint",
+    "legacy_code": "mor",
     "name": "Magnum Opus Reprint",
     "position": 1,
     "size": 6
@@ -571,6 +634,7 @@
     "card_set_type_id": "expansion",
     "date_release": "2019-09-09",
     "id": "uprising_booster_pack",
+    "legacy_code": "urbp",
     "name": "Uprising Booster Pack",
     "position": 2,
     "size": 7
@@ -580,6 +644,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2019-12-31",
     "id": "uprising",
+    "legacy_code": "ur",
     "name": "Uprising",
     "position": 3,
     "size": 65
@@ -589,6 +654,7 @@
     "card_set_type_id": "data_pack",
     "date_release": "2020-12-18",
     "id": "salvaged_memories",
+    "legacy_code": "sm",
     "name": "Salvaged Memories",
     "position": 1,
     "size": 18
@@ -598,6 +664,7 @@
     "card_set_type_id": "core",
     "date_release": "2021-03-28",
     "id": "system_gateway",
+    "legacy_code": "sg",
     "name": "System Gateway",
     "position": 1,
     "size": 77
@@ -607,6 +674,7 @@
     "card_set_type_id": "core",
     "date_release": "2021-03-28",
     "id": "system_update_2021",
+    "legacy_code": "su21",
     "name": "System Update 2021",
     "position": 1,
     "size": 82
@@ -616,6 +684,7 @@
     "card_set_type_id": "expansion",
     "date_release": "2022-03-18",
     "id": "midnight_sun_booster_pack",
+    "legacy_code": "msbp",
     "name": "Midnight Sun Booster Pack",
     "position": 1,
     "size": 7
@@ -625,6 +694,7 @@
     "card_set_type_id": "expansion",
     "date_release": "2022-07-22",
     "id": "midnight_sun",
+    "legacy_code": "ms",
     "name": "Midnight Sun",
     "position": 2,
     "size": 65


### PR DESCRIPTION
This enables interop with NRDB classic.  We had printing codes, but not legacy codes for card sets and card cycles.