### PR TITLE
Fix cycle and set specification for startup card pools.

### DIFF
--- a/v2/card_pools/startup.json
+++ b/v2/card_pools/startup.json
@@ -3,30 +3,44 @@
     "id": "startup_ashes",
     "format_id": "startup",
     "name": "Startup (Ashes)",
-    "card_cycle_ids": ["ashes"],
-    "card_set_ids": ["system_gateway", "system_update_2021"]
+    "card_cycle_ids": ["ashes", "system_gateway", "system_update_2021"],
+    "card_set_ids": [
+      "downfall",
+      "system_gateway",
+      "system_update_2021",
+      "uprising"
+    ]
   },
   {
     "id": "startup_ashes_plus",
     "format_id": "startup",
     "name": "Startup (Ashes+)",
-    "card_cycle_ids": ["ashes"],
+    "card_cycle_ids": ["ashes", "system_gateway", "system_update_2021"],
     "card_set_ids": [
+      "downfall",
       "midnight_sun_booster_pack",
       "system_gateway",
-      "system_update_2021"
+      "system_update_2021",
+      "uprising"
     ]
   },
   {
     "id": "startup_ashes_plus_midnight_sun",
     "format_id": "startup",
     "name": "Startup (Ashes + Midnight Sun)",
-    "card_cycle_ids": ["ashes"],
+    "card_cycle_ids": [
+      "ashes",
+      "borealis",
+      "system_gateway",
+      "system_update_2021"
+    ],
     "card_set_ids": [
+      "downfall",
       "midnight_sun",
       "midnight_sun_booster_pack",
       "system_gateway",
-      "system_update_2021"
+      "system_update_2021",
+      "uprising"
     ]
   }
 ]


### PR DESCRIPTION
We had a slightly wonky specification for the card pools here.

I'll add a test as a followup, but card pools should list cycles for any cycles that are completely encompassed and the sets should also be spelled out explicitly.

It's OK to have 1 set from a cycle specified, but not to have a missing set from a cycle for eternal, standard, snapshot, or startup.