### PR TITLE
Cleaned up card set types

### DIFF
--- a/schema/v2/card_set_types_schema.json
+++ b/schema/v2/card_set_types_schema.json
@@ -15,8 +15,13 @@
         "description": "Name of the type of set.",
         "minLength": 1,
         "type": "string"
+      },
+      "description": {
+        "description": "A brief explanation of the type of set.",
+        "minLength": 1,
+        "type": "string"
       }
     },
-    "required": ["id", "name"]
+    "required": ["id", "name", "description"]
   }
 }

--- a/v2/card_set_types.json
+++ b/v2/card_set_types.json
@@ -1,5 +1,9 @@
 [
   {
+    "id": "booster_pack",
+    "name": "Booster Pack"
+  },
+  {
     "id": "campaign",
     "name": "Campaign"
   },

--- a/v2/card_set_types.json
+++ b/v2/card_set_types.json
@@ -1,34 +1,42 @@
 [
   {
     "id": "booster_pack",
-    "name": "Booster Pack"
+    "name": "Booster Pack",
+    "description": "A booster pack released as a subset of a larger release."
   },
   {
     "id": "campaign",
-    "name": "Campaign"
+    "name": "Campaign",
+    "description": "A campaign set not released for legal play."
   },
   {
     "id": "core",
-    "name": "Core"
+    "name": "Core",
+    "description": "A core set, or set that makes up part of the core selection of cards."
   },
   {
     "id": "data_pack",
-    "name": "Data Pack"
+    "name": "Data Pack",
+    "description": "The major releases of each cycle."
   },
   {
     "id": "deluxe",
-    "name": "Deluxe"
+    "name": "Deluxe",
+    "description": "A non-core set released in a big box."
   },
   {
     "id": "draft",
-    "name": "Draft"
+    "name": "Draft",
+    "description": "A draft-exclusive sets."
   },
   {
     "id": "expansion",
-    "name": "Expansion"
+    "name": "Expansion",
+    "description": "A miscellaneous set released for legal play."
   },
   {
     "id": "promo",
-    "name": "Promo"
+    "name": "Promo",
+    "description": "A promotional set not released for legal play."
   }
 ]

--- a/v2/card_sets.json
+++ b/v2/card_sets.json
@@ -441,7 +441,7 @@
   },
   {
     "card_cycle_id": "terminal_directive",
-    "card_set_type_id": "data_pack",
+    "card_set_type_id": "deluxe",
     "date_release": "2017-04-27",
     "id": "terminal_directive_cards",
     "legacy_code": "td",
@@ -631,7 +631,7 @@
   },
   {
     "card_cycle_id": "ashes",
-    "card_set_type_id": "expansion",
+    "card_set_type_id": "booster_pack",
     "date_release": "2019-09-09",
     "id": "uprising_booster_pack",
     "legacy_code": "urbp",
@@ -651,7 +651,7 @@
   },
   {
     "card_cycle_id": "salvaged_memories",
-    "card_set_type_id": "data_pack",
+    "card_set_type_id": "expansion",
     "date_release": "2020-12-18",
     "id": "salvaged_memories",
     "legacy_code": "sm",
@@ -681,7 +681,7 @@
   },
   {
     "card_cycle_id": "borealis",
-    "card_set_type_id": "expansion",
+    "card_set_type_id": "booster_pack",
     "date_release": "2022-03-18",
     "id": "midnight_sun_booster_pack",
     "legacy_code": "msbp",
@@ -691,7 +691,7 @@
   },
   {
     "card_cycle_id": "borealis",
-    "card_set_type_id": "expansion",
+    "card_set_type_id": "data_pack",
     "date_release": "2022-07-22",
     "id": "midnight_sun",
     "legacy_code": "ms",


### PR DESCRIPTION
- Added `booster_pack` as a set type to represent the new trend of releasing booster packs next to full releases
- Made Salvaged Memories an expansion
- Made the constructed Terminal Directive set a deluxe

My reasoning for changing SM and TD from being data packs is it feels inaccurate to call a set that wasn't part of a cycle a data pack. I'm happy to revert these if they make more sense as data packs.

Here's how I'm viewing each type:
- booster_pack (a booster pack; so far a direct subset of another set)
- campaign (Terminal Directive Campaign)
- core (the core sets and system update)
- data_pack (the major releases of each cycle; 6 per FFG cycle and 2 per NISEI cycle)
- deluxe (a set released in a big box)
- draft (draft)
- expansion (miscellaneous Standard set)
- promo (official non-Standard set; NAPD multiplayer)

Would it be useful to add a description field to `card_set_types.json` explaining what all the types represent?