### PR TITLE
Set Liberation cycle to size 2 (2 packs).

### DIFF
--- a/cycles.json
+++ b/cycles.json
@@ -186,6 +186,6 @@
     "name": "Liberation",
     "position": 33,
     "rotated": false,
-    "size": 1
+    "size": 2
   }
 ]


### PR DESCRIPTION
This fixes the set display (at least the text part).

Before:
<img width="593" alt="Screenshot 2023-07-24 at 11 27 27 PM" src="https://github.com/NetrunnerDB/netrunner-cards-json/assets/396562/98aea04d-72c9-465e-9aab-a7a6de916415">

After:
<img width="598" alt="Screenshot 2023-07-24 at 11 27 42 PM" src="https://github.com/NetrunnerDB/netrunner-cards-json/assets/396562/1567da72-d2a2-4226-b12c-1186725df644">
