### PR TITLE
MU notation fixes for Endurance and Masterwork.

### DIFF
--- a/pack/df.json
+++ b/pack/df.json
@@ -290,9 +290,9 @@
     "position": 15,
     "quantity": 3,
     "side_code": "runner",
-    "stripped_text": "+1 mu. The first time each turn you install a piece of hardware, draw 1 card. Whenever a run begins, you may install a piece of hardware, paying 1 credit more. Limit 1 console per player.",
+    "stripped_text": "+1 mu The first time each turn you install a piece of hardware, draw 1 card. Whenever a run begins, you may install a piece of hardware, paying 1 credit more. Limit 1 console per player.",
     "stripped_title": "Masterwork (v37)",
-    "text": "+1[mu].\nThe first time each turn you install a piece of hardware, draw 1 card.\nWhenever a run begins, you may install a piece of hardware, paying 1[credit] more.\nLimit 1 <strong>console</strong> per player.",
+    "text": "+1[mu]\nThe first time each turn you install a piece of hardware, draw 1 card.\nWhenever a run begins, you may install a piece of hardware, paying 1[credit] more.\nLimit 1 <strong>console</strong> per player.",
     "title": "Masterwork (v37)",
     "type_code": "hardware",
     "uniqueness": true

--- a/pack/ms.json
+++ b/pack/ms.json
@@ -495,7 +495,7 @@
     "position": 25,
     "quantity": 3,
     "side_code": "runner",
-    "stripped_text": "+2mu When you install this hardware, place 3 power counters on it. The first time each turn you make a successful run, place 1 power counter on this hardware. 2 hosted power counters: Break up to 2 subroutines. Limit 1 console per player.",
+    "stripped_text": "+2 mu When you install this hardware, place 3 power counters on it. The first time each turn you make a successful run, place 1 power counter on this hardware. 2 hosted power counters: Break up to 2 subroutines. Limit 1 console per player.",
     "stripped_title": "Endurance",
     "text": "+2[mu]\nWhen you install this hardware, place 3 power counters on it.\nThe first time each turn you make a successful run, place 1 power counter on this hardware.\n<strong>2 hosted power counters:</strong> Break up to 2 subroutines.\nLimit 1 <strong>console</strong> per player.",
     "title": "Endurance",

--- a/v2/cards/endurance.json
+++ b/v2/cards/endurance.json
@@ -7,7 +7,7 @@
   "influence_cost": 5,
   "is_unique": true,
   "side_id": "runner",
-  "stripped_text": "+2mu When you install this hardware, place 3 power counters on it. The first time each turn you make a successful run, place 1 power counter on this hardware. 2 hosted power counters: Break up to 2 subroutines. Limit 1 console per player.",
+  "stripped_text": "+2 mu When you install this hardware, place 3 power counters on it. The first time each turn you make a successful run, place 1 power counter on this hardware. 2 hosted power counters: Break up to 2 subroutines. Limit 1 console per player.",
   "stripped_title": "Endurance",
   "subtypes": ["console", "vehicle"],
   "text": "+2[mu]\nWhen you install this hardware, place 3 power counters on it.\nThe first time each turn you make a successful run, place 1 power counter on this hardware.\n<strong>2 hosted power counters:</strong> Break up to 2 subroutines.\nLimit 1 <strong>console</strong> per player.",

--- a/v2/cards/masterwork_v37.json
+++ b/v2/cards/masterwork_v37.json
@@ -7,9 +7,9 @@
   "influence_cost": 4,
   "is_unique": true,
   "side_id": "runner",
-  "stripped_text": "+1 mu. The first time each turn you install a piece of hardware, draw 1 card. Whenever a run begins, you may install a piece of hardware, paying 1 credit more. Limit 1 console per player.",
+  "stripped_text": "+1 mu The first time each turn you install a piece of hardware, draw 1 card. Whenever a run begins, you may install a piece of hardware, paying 1 credit more. Limit 1 console per player.",
   "stripped_title": "Masterwork (v37)",
   "subtypes": ["console"],
-  "text": "+1[mu].\nThe first time each turn you install a piece of hardware, draw 1 card.\nWhenever a run begins, you may install a piece of hardware, paying 1[credit] more.\nLimit 1 <strong>console</strong> per player.",
+  "text": "+1[mu]\nThe first time each turn you install a piece of hardware, draw 1 card.\nWhenever a run begins, you may install a piece of hardware, paying 1[credit] more.\nLimit 1 <strong>console</strong> per player.",
   "title": "Masterwork (v37)"
 }


### PR DESCRIPTION
1. Endurance is missing a space between "+2" and "MU" (in its `stripped_text`)
2. Masterwork has an errant period at the end of its "+1 MU"