### PR TITLE
small replacements to Makers Eye, Aesops, and Tomorrows headline

### DIFF
--- a/pack/core.json
+++ b/pack/core.json
@@ -723,7 +723,7 @@
     "stripped_text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
     "stripped_title": "The Maker's Eye",
     "text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
-    "title": "The Maker’s Eye",
+    "title": "The Maker's Eye",
     "type_code": "event",
     "uniqueness": false
   },
@@ -947,7 +947,7 @@
     "stripped_text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3 credits.",
     "stripped_title": "Aesop's Pawnshop",
     "text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3[credit].",
-    "title": "Aesop’s Pawnshop",
+    "title": "Aesop's Pawnshop",
     "type_code": "resource",
     "uniqueness": true
   },

--- a/pack/core2.json
+++ b/pack/core2.json
@@ -861,7 +861,7 @@
     "stripped_text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
     "stripped_title": "The Maker's Eye",
     "text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
-    "title": "The Maker’s Eye",
+    "title": "The Maker's Eye",
     "type_code": "event",
     "uniqueness": false
   },
@@ -1045,7 +1045,7 @@
     "stripped_text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3 credits.",
     "stripped_title": "Aesop's Pawnshop",
     "text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3[credit].",
-    "title": "Aesop’s Pawnshop",
+    "title": "Aesop's Pawnshop",
     "type_code": "resource",
     "uniqueness": true
   },

--- a/pack/sc19.json
+++ b/pack/sc19.json
@@ -918,7 +918,7 @@
     "stripped_text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
     "stripped_title": "The Maker's Eye",
     "text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
-    "title": "The Maker’s Eye",
+    "title": "The Maker's Eye",
     "type_code": "event",
     "uniqueness": false
   },
@@ -1125,7 +1125,7 @@
     "stripped_text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3 credits.",
     "stripped_title": "Aesop's Pawnshop",
     "text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3[credit].",
-    "title": "Aesop’s Pawnshop",
+    "title": "Aesop's Pawnshop",
     "type_code": "resource",
     "uniqueness": true
   },

--- a/pack/sg.json
+++ b/pack/sg.json
@@ -1054,7 +1054,7 @@
     "stripped_text": "When this agenda is scored or stolen, give the Runner 1 tag. Limit 1 per deck.",
     "stripped_title": "Tomorrow's Headline",
     "text": "When this agenda is scored or stolen, give the Runner 1 tag.\nLimit 1 per deck.",
-    "title": "Tomorrowʼs Headline",
+    "title": "Tomorrow's Headline",
     "type_code": "agenda",
     "uniqueness": false
   },

--- a/pack/su21.json
+++ b/pack/su21.json
@@ -585,7 +585,7 @@
     "stripped_text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
     "stripped_title": "The Maker's Eye",
     "text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
-    "title": "The Maker’s Eye",
+    "title": "The Maker's Eye",
     "type_code": "event",
     "uniqueness": false
   },
@@ -712,7 +712,7 @@
     "stripped_text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3 credits.",
     "stripped_title": "Aesop's Pawnshop",
     "text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3[credit].",
-    "title": "Aesop’s Pawnshop",
+    "title": "Aesop's Pawnshop",
     "type_code": "resource",
     "uniqueness": true
   },

--- a/v2/cards/aesops_pawnshop.json
+++ b/v2/cards/aesops_pawnshop.json
@@ -12,5 +12,5 @@
   "stripped_title": "Aesop's Pawnshop",
   "subtypes": ["connection", "location"],
   "text": "When your turn begins, you may trash 1 of your other installed cards. If you do, gain 3[credit].",
-  "title": "Aesop’s Pawnshop"
+  "title": "Aesop's Pawnshop"
 }

--- a/v2/cards/the_makers_eye.json
+++ b/v2/cards/the_makers_eye.json
@@ -12,5 +12,5 @@
   "stripped_title": "The Maker's Eye",
   "subtypes": ["run"],
   "text": "Run R&D. If successful, access 2 additional cards when you breach R&D.",
-  "title": "The Maker’s Eye"
+  "title": "The Maker's Eye"
 }

--- a/v2/cards/tomorrows_headline.json
+++ b/v2/cards/tomorrows_headline.json
@@ -12,5 +12,5 @@
   "stripped_title": "Tomorrow's Headline",
   "subtypes": ["ambush"],
   "text": "When this agenda is scored or stolen, give the Runner 1 tag.\nLimit 1 per deck.",
-  "title": "Tomorrowʼs Headline"
+  "title": "Tomorrow's Headline"
 }

--- a/v2/rulings/aesops_pawnshop.json
+++ b/v2/rulings/aesops_pawnshop.json
@@ -4,6 +4,6 @@
     "card_id": "aesops_pawnshop",
     "date_update": "2022-04-23",
     "nsg_rules_team_verified": false,
-    "question": "Can [Aesop’s Pawnshop](https://netrunnerdb.com/en/card/31035) be used multiple times in a turn to trash multiple cards?"
+    "question": "Can [Aesop's Pawnshop](https://netrunnerdb.com/en/card/31035) be used multiple times in a turn to trash multiple cards?"
   }
 ]


### PR DESCRIPTION
GLC had a comment on how Tomorrow's headline in particular has the weird ' after the SU remaster update and that it's breaking JNet. 

This should revert titles to make things a bit better? 