### PR TITLE
startup_liberation is active Startup card pool.

### DIFF
--- a/v2/formats/startup.json
+++ b/v2/formats/startup.json
@@ -28,14 +28,14 @@
       "id": "startup_4"
     },
     {
-      "active": true,
+      "active": false,
       "card_pool_id": "startup_borealis_plus_the_automata_initiative",
       "date_start": "2024-01-19",
       "id": "startup_5",
       "restriction_id": "startup_ban_list_24_01"
     },
     {
-      "active": false,
+      "active": true,
       "card_pool_id": "startup_liberation",
       "date_start": "2024-03-30",
       "id": "startup_6",


### PR DESCRIPTION
We missed this a while back so https://netrunnerdb.com/en/formats is showing the wrong thing.