### PR TITLE
removed Funhouse Flavour Text from Spin Doctor

### DIFF
--- a/pack/sg.json
+++ b/pack/sg.json
@@ -1064,7 +1064,7 @@
     "deck_limit": 3,
     "faction_code": "nbn",
     "faction_cost": 1,
-    "flavor": "“Itʼs worse than dead meat—your project is too toxic to even feed to the vultures! If you don’t want to <strong>join</strong> it in the bloody memory hole, crawl onto every business show you can and wallow in blame like a pig in muck.”\n“I might take a break from VR after this one.”",
+    "flavor": "“Itʼs worse than dead meat—your project is too toxic to even feed to the vultures! If you don’t want to <strong>join</strong> it in the bloody memory hole, crawl onto every business show you can and wallow in blame like a pig in muck.”",
     "illustrator": "David Lei",
     "keywords": "Character",
     "pack_code": "sg",

--- a/v2/printings/system_gateway.json
+++ b/v2/printings/system_gateway.json
@@ -521,7 +521,7 @@
   {
     "card_id": "spin_doctor",
     "card_set_id": "system_gateway",
-    "flavor": "“Itʼs worse than dead meat—your project is too toxic to even feed to the vultures! If you don’t want to <strong>join</strong> it in the bloody memory hole, crawl onto every business show you can and wallow in blame like a pig in muck.”\n“I might take a break from VR after this one.”",
+    "flavor": "“Itʼs worse than dead meat—your project is too toxic to even feed to the vultures! If you don’t want to <strong>join</strong> it in the bloody memory hole, crawl onto every business show you can and wallow in blame like a pig in muck.”",
     "id": "30053",
     "illustrator": "David Lei",
     "position": 53,


### PR DESCRIPTION
During the Remaster import we have erroneous flavour text for spin doctor. This should remove the extra line from Funhouse's flavour text that snuck in. 